### PR TITLE
Used child process/spawn rather then exec to fix maxBuffer bug

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -30,6 +30,7 @@
   , "beforeEach"
   , "after"
   , "afterEach"
+  , "Promise"
   ]
 , "quotmark": "single"
 , "smarttabs": true


### PR DESCRIPTION
Hi,

Re: [https://github.com/domharrington/node-gitlog/issues/16](https://github.com/domharrington/node-gitlog/issues/16) ,this PR uses spawn/child process rather then exec() to fix the max buffer bug on that issue.

most of the code is the same except the args are built as an array rather than concat'ing a string.

All tests pass

Andrew