### PR TITLE
Rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ var gitlog = require('gitlog')
       , 'authorName'
       , 'authorDateRel'
       ]
+    , execOptions:
+      { maxBuffer: 1000 x 1024
+      }
     }
 
 gitlog(options, function(error, commits) {
@@ -59,6 +62,20 @@ Below fields was returned from the log:
 
 This option is enabled by default.
 
+### execOptions
+
+Type: `Object`
+
+Specify some options to be passed to the [.exec()](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) method:
+
+- `cwd` String *Current working directory of the child process*
+- `env` Object *Environment key-value pairs*
+- `setsid` Boolean
+- `encoding` String *(Default: 'utf8')*
+- `timeout` Number *(Default: 0)*
+- `maxBuffer` Number *(Default: 200\*1024)*
+- `killSignal` String *(Default: 'SIGTERM')*
+
 ### optional fields
 An array of fields to return from the log, here are the possible options:
 
@@ -78,7 +95,6 @@ An array of fields to return from the log, here are the possible options:
 - committerDateRel - relative committer date
 - subject - commit message (first line)
 - body - full commit message
-
 
 Defaults to 'abbrevHash', 'hash', 'subject' and 'authorName'.
 

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ function gitlog(options, cb) {
     }
     debug('commits',commits)
 
-    commits = parseCommits(commits, options.fields,options.nameStatus)
+    commits = parseCommits(commits, options.fields, options.nameStatus)
 
     cb(stderr || err, commits)
   })
@@ -107,13 +107,32 @@ function fileNameAndStatus(options) {
   return options.nameStatus ? ' --name-status' : '';
 }
 
-function parseCommits(commits, fields,nameStatus) {
+function parseCommits(commits, fields, nameStatus) {
   return commits.map(function(commit) {
     var parts = commit.split('@end@\n\n')
+
     commit = parts[0].split(delimiter)
 
     if (parts[1]) {
-      commit = commit.concat(parts[1].replace(/\n/g, '\t').split(delimiter))
+      var parseNameStatus = parts[1].split('\n');
+
+      // Removes last empty char if exists
+      if (parseNameStatus[parseNameStatus.length - 1] === ''){
+        parseNameStatus.pop()
+      }
+
+      // Split each line into it's own delimitered array
+      parseNameStatus.forEach(function(d, i) {
+        parseNameStatus[i] = d.split(delimiter);
+      });
+
+      // 0 will always be status, last will be the filename as it is in the commit,
+      // anything inbetween could be the old name if renamed or copied
+      parseNameStatus = parseNameStatus.reduce(function(a, b) {
+        return a.concat([ b[ 0 ], b[ b.length - 1 ] ]);
+      }, [])
+
+      commit = commit.concat(parseNameStatus)
     }
 
     debug('commit', commit)
@@ -123,16 +142,19 @@ function parseCommits(commits, fields,nameStatus) {
 
     var parsed = {}
 
+    if (nameStatus){
+      // Create arrays for non optional fields if turned on
+      notOptFields.forEach(function(d) {
+        parsed[d] = [];
+      })
+    }
+
     commit.forEach(function(commitField, index) {
       if (fields[index]) {
         parsed[fields[index]] = commitField
       } else {
         if (nameStatus){
-          var pos = (index - fields.length)  % notOptFields.length
-
-          if (!parsed[notOptFields[pos]]) {
-            parsed[notOptFields[pos]] = []
-          }
+          var pos = (index - fields.length) % notOptFields.length
 
           debug('nameStatus', (index - fields.length) ,notOptFields.length,pos,commitField)
           parsed[notOptFields[pos]].push(commitField)

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function gitlog(options, cb) {
     { number: 10
     , fields: [ 'abbrevHash', 'hash', 'subject', 'authorName' ]
     , nameStatus:true
+    , execOptions: {}
     }
 
   // Set defaults
@@ -85,8 +86,8 @@ function gitlog(options, cb) {
   //File and file status
   command += fileNameAndStatus(options)
 
-  debug('command', command)
-  exec(command, function(err, stdout, stderr) {
+  debug('command', options.execOptions, command)
+  exec(command, options.execOptions, function(err, stdout, stderr) {
     debug('stdout',stdout)
     var commits = stdout.split('\n@begin@')
     if (commits.length === 1 && commits[0] === '' ){

--- a/test/create-repo.sh
+++ b/test/create-repo.sh
@@ -10,7 +10,7 @@ cd test-repo-clone
 git config --local user.email "you@example.com"
 git config --local user.name "Your Name"
 
-for i in {1..20}
+for i in {1..17}
   do
     FILE=$i-file
     touch $FILE
@@ -19,15 +19,32 @@ for i in {1..20}
     git commit -m "$i commit"
   done
 
-git symbolic-ref HEAD refs/heads/test-branch
-rm .git/index
-git clen -fdx
+mv 1-file 1-fileRename
+mv 2-file 2-fileRename
+git add .
 
-for x in {1..15}
-  do
-    FILE=$x-file-$x
-    touch $FILE
-    git add $FILE
+git commit -m "$2 files renamed"
 
-    git commit -m "$x commit"
-  done
+rm -rf 1-fileRename
+git add -A 1-fileRename
+
+git commit -m "1 file removed"
+
+chmod 744 2-fileRename
+chmod 744 3-file
+git add .
+
+git commit -m "1 file modified"
+
+# git symbolic-ref HEAD refs/heads/test-branch
+# rm .git/index
+# git clen -fdx
+
+# for x in {1..15}
+#   do
+#     FILE=$x-file-$x
+#     touch $FILE
+#     git add $FILE
+
+#     git commit -m "$x commit"
+#   done

--- a/test/gitlog.test.js
+++ b/test/gitlog.test.js
@@ -45,6 +45,7 @@ describe('gitlog', function() {
   it('returns 20 commits from specified branch', function(done) {
     gitlog({ repo: testRepoLocation, branch: 'master', number: 100 }, function(err, commits) {
       commits.length.should.equal(20)
+
       done()
     })
   })
@@ -173,6 +174,34 @@ describe('gitlog', function() {
 
         done()
       })
+    })
+  })
+
+  it('returns A status for files that are added', function(done) {
+    gitlog({ repo: testRepoLocation }, function(err, commits) {
+      commits[0].status[0].should.equal('A')
+      done()
+    })
+  })
+
+  it('returns M status for files that are modified', function(done) {
+    gitlog({ repo: testRepoLocation }, function(err, commits) {
+      commits[1].status[0].should.equal('M')
+      done()
+    })
+  })
+
+  it('returns D status for files that are deleted', function(done) {
+    gitlog({ repo: testRepoLocation }, function(err, commits) {
+      commits[2].status[0].should.equal('D')
+      done()
+    })
+  })
+
+  it('returns R100 status for files that are renamed (100 is % of similarity)', function(done) {
+    gitlog({ repo: testRepoLocation }, function(err, commits) {
+      commits[3].status[0].should.equal('R100')
+      done()
     })
   })
 


### PR DESCRIPTION
Hey, i was using this in a project the other day and noticed some strange behaviour when file renames occur. I've added a failing test case and some test cases for added and removed files as well. Basically when a file is renamed the status array and the files array become mixed, i'm not really sure what the desired behaviour is supposed to be, a status code 'R' with the new filename in files?

Here's an example of the commit object when a rename has occurred;

```
{
    "abbrevHash": "b89215b",
    "hash": "b89215b6dd6a2c27e47789bf954e5644e0d0aa78",
    "subject": " files renamed",
    "authorName": "Your Name",
    "status": [
        "R100",
        "1-fileRename",
        "2-file"
    ],
    "files": [
        "1-file",
        "R100",
        "2-fileRename"
    ]
}
```

So here two files have been renamed using

```
mv 1-file 1-fileRename
mv 2-file 2-fileRename
```

As you can see it seems to be mixing the status's and the files at this point, i'm not really sure what the ideal behaviour is supposed to be here, if you could take a look and let me know how its supposed to work, i'm happy to implement the code.

Regards

Mike

**Edit**

Also after seeing the report from CI it seems to output a slightly different object, i'm assuming the CI is set to use an older version of git.

```
{
    "abbrevHash": "4bcd6de",
    "hash": "4bcd6deaee38e3c8393c6c7f3896347a0ce6b591",
    "subject": " files renamed",
    "authorName": "Your Name",
    "status": [
        "A",
        "A"
    ],
    "files": [
        "1-fileRename",
        "2-fileRename"
    ]
}
```

If this is the desired behaviour then it would seem that something has changed in recent versions of git that means renames are reported differently than just Add's. I'm using git 2.9.0