### PR TITLE
Add all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Much more likely to set status codes to 'C' if files are exact copies of each ot
 
 This option is disabled by default.
 
+### all
+Find commits on all branches instead of just on the current one.
+
+This option is disabled by default.
+
 ### execOptions
 
 Type: `Object`

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ function gitlog(options, cb) {
     , fields: [ 'abbrevHash', 'hash', 'subject', 'authorName' ]
     , nameStatus:true
     , findCopiesHarder:false
+    , all:false
     , execOptions: {}
     }
 
@@ -63,6 +64,10 @@ function gitlog(options, cb) {
 
   if (options.findCopiesHarder){
     command += '--find-copies-harder '
+  }
+
+  if (options.all){
+    command += '--all '
   }
 
   command += '-n ' + options.number

--- a/test/create-repo.sh
+++ b/test/create-repo.sh
@@ -42,6 +42,13 @@ cp 3-file copy-file
 git add copy-file
 git commit -m "1 file copied"
 
+# New branch
+git checkout -b new-branch
+touch new-file
+git add new-file
+git commit -m "Added new file on new branch"
+git checkout master
+
 # git symbolic-ref HEAD refs/heads/test-branch
 # rm .git/index
 # git clen -fdx

--- a/test/gitlog.test.js
+++ b/test/gitlog.test.js
@@ -54,6 +54,20 @@ describe('gitlog', function() {
     })
   })
 
+  it('returns 20 commits from repository with all=false', function(done) {
+    gitlog({ repo: testRepoLocation, all: false, number: 100 }, function(err, commits) {
+      commits.length.should.equal(20)
+      done()
+    })
+  })
+
+  it('returns 21 commits from repository with all=true', function(done) {
+    gitlog({ repo: testRepoLocation, all: true, number: 100 }, function(err, commits) {
+      commits.length.should.equal(21)
+      done()
+    })
+  })
+
   it('defaults to 10 commits', function(done) {
     gitlog({ repo: testRepoLocation }, function(err, commits) {
       commits.length.should.equal(10)


### PR DESCRIPTION
Add option 'all' to return all commits in a repository, instead of just the ones on the current branch.