### PR TITLE
Synchronous operation and branch (revision range) docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Git log parser for Node.JS
 ## Usage
 
 ```js
-var gitlog = require('gitlog')
-  , options =
+const gitlog = require('gitlog');
+
+const options =
     { repo: __dirname + '/test-repo-folder'
     , number: 20
     , author: 'Dom Harrington'
@@ -27,12 +28,17 @@ var gitlog = require('gitlog')
     , execOptions:
       { maxBuffer: 1000 x 1024
       }
-    }
+    };
 
+// Asynchronous (with Callback)
 gitlog(options, function(error, commits) {
   // Commits is an array of commits in the repo
   console.log(commits)
-})
+});
+
+// Synchronous
+let commits = gitlog(options);
+console.log(commits);
 ```
 
 ## Options
@@ -71,6 +77,11 @@ This option is disabled by default.
 Find commits on all branches instead of just on the current one.
 
 This option is disabled by default.
+
+### branch ([revision range](https://git-scm.com/docs/git-log#git-log-ltrevisionrangegt))
+Show only commits in the specified branch or revision range. 
+
+By default uses the current branch and defaults to `HEAD` (i.e. the whole history leading to the current commit).
 
 ### execOptions
 

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ function gitlog(options, cb) {
   // Close custom format
   command += '@end@"'
 
-  // Append branch if specified
+  // Append branch (revision range) if specified
   if (options.branch) {
     command += ' ' + options.branch
   }

--- a/test/gitlog.test.js
+++ b/test/gitlog.test.js
@@ -47,9 +47,17 @@ describe('gitlog', function() {
     }).should.throw('Unknown field: ' + field)
   })
 
-  it('returns 20 commits from specified branch', function(done) {
-    gitlog({ repo: testRepoLocation, branch: 'master', number: 100 }, function(err, commits) {
-      commits.length.should.equal(20)
+  it('returns 21 commits from specified branch', function(done) {
+    gitlog({ repo: testRepoLocation, branch: 'new-branch', number: 100 }, function(err, commits) {
+      commits.length.should.equal(21)
+      done()
+    })
+  })
+
+  it('returns 1 commit from specified revision range', function(done) {
+    gitlog({ repo: testRepoLocation, branch: 'master..new-branch', number: 100 }, function(err, commits) {
+      commits.length.should.equal(1)
+      commits[0].subject.should.equal('Added new file on new branch')
       done()
     })
   })


### PR DESCRIPTION
Commits:
- docs(readme): add docs for synchronous operation and branch (revision range) option
- test(branch): add test for branch (revision range)

Also made the example readme more clear and changed `var` to `const` to keep inline with modern ES6 syntax. See [chalk documentation](https://github.com/chalk/chalk#usage) for a similar example.