### PR TITLE
Fix for the `file` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Show only commits in the specified branch or revision range.
 
 By default uses the current branch and defaults to `HEAD` (i.e. the whole history leading to the current commit).
 
+### file
+Optional file filter for the `git log` command
+
 ### execOptions
 
 Type: `Object`

--- a/index.js
+++ b/index.js
@@ -88,12 +88,12 @@ function gitlog(options, cb) {
     command += ' ' + options.branch
   }
 
+  //File and file status
+  command += fileNameAndStatus(options)
+
   if (options.file) {
     command += ' -- ' + options.file
   }
-
-  //File and file status
-  command += fileNameAndStatus(options)
 
   debug('command', options.execOptions, command)
 


### PR DESCRIPTION
Enable `node-gitlog` to filter the commits based on a file spec.