### PR TITLE
add includeMergeCommitFiles to pass -m flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Much more likely to set status codes to 'C' if files are exact copies of each ot
 
 This option is disabled by default.
 
+### includeMergeCommitFiles
+Pass the `-m` option to includes files in a merge commit.
+
+This option is disabled by default.
+
 ### all
 Find commits on all branches instead of just on the current one.
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function gitlog(options, cb) {
     { number: 10
     , fields: [ 'abbrevHash', 'hash', 'subject', 'authorName' ]
     , nameStatus:true
+    , includeMergeCommitFiles:false
     , findCopiesHarder:false
     , all:false
     , execOptions: { cwd: options.repo }
@@ -65,6 +66,10 @@ function gitlog(options, cb) {
 
   if (options.all){
     command += '--all '
+  }
+
+  if (options.includeMergeCommitFiles){
+    command += '-m '
   }
 
   command += '-n ' + options.number

--- a/test/create-repo.sh
+++ b/test/create-repo.sh
@@ -51,7 +51,9 @@ git checkout master
 
 # Merge commit
 git checkout -b new-merge-branch
-git commit -m "Commit to be merged" --allow-empty
+touch foo
+git add foo
+git commit -m "Commit to be merged"
 git checkout master
 git merge --no-edit --no-ff new-merge-branch
 git branch -d new-merge-branch

--- a/test/gitlog.test.js
+++ b/test/gitlog.test.js
@@ -237,6 +237,13 @@ describe('gitlog', function() {
     })
   })
 
+  it('returns merge commits files when includeMergeCommitFiles is true', function(done) {
+    gitlog({ repo: testRepoLocation, includeMergeCommitFiles: true }, function(err, commits) {
+      commits[0].files[0].should.equal('foo')
+      done()
+    })
+  })
+
   it('returns M status for files that are modified', function(done) {
     gitlog({ repo: testRepoLocation }, function(err, commits) {
       commits[3].status[0].should.equal('M')


### PR DESCRIPTION
Thanks for the awesome package! We use it to power the internals in [auto](https://github.com/intuit/auto). 🎉 

One thing we've found we want is merge commits files for changelogs.

This change will include the files changed in a merge commit. By default git doesn't return this value.

closes #40 