### PR TITLE
update readme to fix cjs usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install gitlog --save
 ## Usage
 
 ```js
-const gitlog = require("gitlog");
+const gitlog = require("gitlog").default;
 
 const options = {
   repo: __dirname + "/test-repo-folder",
@@ -34,8 +34,10 @@ gitlog(options, function (error, commits) {
   console.log(commits);
 });
 
+const { gitlogPromise } = require("gitlog");
+
 // Asynchronous (with Promise)
-gitlog(options)
+gitlogPromise(options)
   .then((commits) => console.log(commits))
   .catch((err) => console.log(err));
 ```


### PR DESCRIPTION
The typescript rewrite ended up being a major because cjs users now need to import `require('gitlog').default`. Oops!

closes #52 