### PR TITLE
Security Fix for RCE on "gitlogplus" - huntr.dev

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { exec, execSync, ExecSyncOptions, ExecException } from "child_process";
+import { execFile, execFileSync, ExecSyncOptions, ExecException } from "child_process";
 import { existsSync } from "fs";
 import createDebugger from "debug";
 
@@ -323,9 +323,11 @@ function gitlog<Field extends CommitField = DefaultField>(
   };
   const execOptions = { cwd: userOptions.repo, ...userOptions.execOptions };
   const command = createCommand(options);
+  
+  command = command.split(' ');
 
   if (!cb) {
-    const stdout = execSync(command, execOptions).toString();
+    const stdout = execFileSync(command[0], command.slice(1), execOptions).toString();
     const commits = stdout.split("@begin@");
 
     if (commits[0] === "") {
@@ -336,7 +338,7 @@ function gitlog<Field extends CommitField = DefaultField>(
     return parseCommits(commits, options.fields, options.nameStatus);
   }
 
-  exec(command, execOptions, (err, stdout, stderr) => {
+  execFile(command[0], command.slice(1), execOptions, (err, stdout, stderr) => {
     debug("stdout", stdout);
     const commits = stdout.split("@begin@");
 


### PR DESCRIPTION
https://huntr.dev/users/Asjidkalam has fixed the RCE on "gitlogplus" vulnerability 🔨. Asjidkalam has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/node-gitlog/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/gitlogplus/1/README.md

### User Comments:

### 📊 Metadata *

Code execution vulnerability 
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-gitlogplus

### ⚙️ Description *

The gitlogplus module is vulnerable against an arbitrary command injection issue which is made possible since some user-inputs are executed inside a command which doesn't have validations of any kind. The argument options can be controlled by users without any sanitization. It was using `exec()` & `execSync()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` and `execFileSync` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code:
```javascript
var git = require('gitlogplus');
git({repo:'.', number:'eeee; touch HACKED; #'})
```
A file named `HACKED` will be created in the current working directory.

![image](https://user-images.githubusercontent.com/16708391/92496554-e6e19580-f215-11ea-8b07-435e71649950.png)


### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

![image](https://user-images.githubusercontent.com/16708391/92496749-2a3c0400-f216-11ea-9277-5b5b86515398.png)



### 👍 User Acceptance Testing (UAT)

Only `execFile` and `execFileSync` is used, no breaking changes introduced.
