### PR TITLE
Patch command injection vulnerability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ const defaultOptions = {
 };
 
 /** Add optional parameter to command */
-function addOptionalArgument<Field extends string = DefaultField>(
+function addOptionalArguments<Field extends string = DefaultField>(
   command: string[],
   options: GitlogOptions<Field>
 ) {
@@ -254,7 +254,7 @@ function createCommandArguments<T extends CommitField | DefaultField = DefaultFi
 
   command.push(`-n ${options.number}`);
 
-  command = addOptionalArgument(command, options);
+  command = addOptionalArguments(command, options);
 
   // Start of custom format
   let prettyArgument: string = '--pretty=@begin@';

--- a/test/gitlog.test.ts
+++ b/test/gitlog.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable handle-callback-err, no-unused-expressions */
 
+import fs from "fs";
 import { exec, execSync } from "child_process";
 import gitlog, { gitlogPromise } from "../src";
 
@@ -318,6 +319,20 @@ describe("gitlog", () => {
       },
     });
     expect(commitsForLastLine.length).toBe(3);
+  });
+
+  it("should not execute shell commands", (done) => {
+    gitlog({
+      repo: testRepoLocation,
+      branch: "$(touch ../exploit)"
+    }, () => {
+      const exists = fs.existsSync("./test/exploit");
+      expect(exists).toBe(false);
+      if (exists) {
+        fs.unlinkSync("./test/exploit");
+      }
+      done();
+    });
   });
 
   afterAll(() => {


### PR DESCRIPTION
I made the necessary changes to use `execFile` and `execFileSync` instead of `exec` and `execSync` and also added a test to avoid regression.

closes: #64