### PR TITLE
Make sure that errors throw Error instead of string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -380,10 +380,11 @@ function gitlog<Field extends CommitField = DefaultField>(
 
     debug("commits", commits);
 
-    cb(
-      stderr || err,
-      parseCommits(commits, options.fields, options.nameStatus)
-    );
+    if (stderr) {
+      err = new Error(stderr);
+    }
+
+    cb(err, parseCommits(commits, options.fields, options.nameStatus));
   });
 }
 

--- a/test/gitlog.test.ts
+++ b/test/gitlog.test.ts
@@ -36,6 +36,12 @@ describe("gitlog", () => {
     );
   });
 
+  it("throws an error when bad option - promise", async () => {
+    await expect(
+      gitlogPromise({ repo: testRepoLocation, branch: "not-a-branch" })
+    ).rejects.toBeInstanceOf(Error);
+  });
+
   it("returns 21 commits from specified branch", (done) => {
     gitlog(
       { repo: testRepoLocation, branch: "new-branch", number: 100 },


### PR DESCRIPTION
Conventionally, thrown exceptions are Error objects instead of strings so that they can capture the stack of where the exception was generated from.

## What's Changing

## Change Type

Indicate the type of change your pull request is:

- [ ] `patch`
- [ ] `minor`
- [x] `major`

I think it's a patch but it is technically a change in the kind of error thrown so could be minor/major? Not sure. I'd like to keep it a patch so if this isn't acceptable I can retrofit an option to change this behavior.

## Release Notes

This release fixes how this library throws errors. Instead of throwing `string` it will throw an actual error. Implementations might need updating.