### PR TITLE
fix: reduce package size by adding files array to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "module": "dist/gitlog.esm.js",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "files": [
+    "dist/*"
+  ],
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",
+    "pretest": "npm run lint",
     "lint": "tsdx lint src test",
     "format": "prettier --write ."
   },


### PR DESCRIPTION
## What's Changing
Before:

```
npm notice
npm notice 📦  gitlog@4.0.8
npm notice === Tarball Contents ===
npm notice 6.1kB  .all-contributorsrc
npm notice 129B   .github/PULL_REQUEST_TEMPLATE.md
npm notice 492B   .github/workflows/ci.yaml
npm notice 37B    .prettierignore
npm notice 9.3kB  CHANGELOG.md
npm notice 1.5kB  LICENSE
npm notice 15.0kB README.md
npm notice 7.0kB  dist/gitlog.cjs.development.js
npm notice 19.0kB dist/gitlog.cjs.development.js.map
npm notice 2.9kB  dist/gitlog.cjs.production.min.js
npm notice 15.1kB dist/gitlog.cjs.production.min.js.map
npm notice 6.8kB  dist/gitlog.esm.js
npm notice 19.0kB dist/gitlog.esm.js.map
npm notice 4.7kB  dist/index.d.ts
npm notice 190B   dist/index.js
npm notice 336B   example/example.js
npm notice 1.4kB  package.json
npm notice 10.8kB src/index.ts
npm notice 1.7kB  test/create-repo.sh
npm notice 48B    test/delete-repo.sh
npm notice 9.8kB  test/gitlog.test.ts
npm notice 694B   tsconfig.json
npm notice === Tarball Details ===
npm notice name:          gitlog
npm notice version:       4.0.8
npm notice filename:      gitlog-4.0.8.tgz
npm notice package size:  26.7 kB
npm notice unpacked size: 132.2 kB
npm notice shasum:        23a24926458ed7a8d762dc1ee96e20b05216d65e
npm notice integrity:     sha512-pP85Mh1Mz3vue[...]3Dmewadw8Ro/g==
npm notice total files:   22
npm notice
gitlog-4.0.8.tgz
```

After:
```
npm notice
npm notice 📦  gitlog@4.0.8
npm notice === Tarball Contents ===
npm notice 1.5kB  LICENSE
npm notice 15.0kB README.md
npm notice 7.0kB  dist/gitlog.cjs.development.js
npm notice 19.0kB dist/gitlog.cjs.development.js.map
npm notice 2.9kB  dist/gitlog.cjs.production.min.js
npm notice 15.1kB dist/gitlog.cjs.production.min.js.map
npm notice 6.8kB  dist/gitlog.esm.js
npm notice 19.0kB dist/gitlog.esm.js.map
npm notice 4.7kB  dist/index.d.ts
npm notice 190B   dist/index.js
npm notice 1.4kB  package.json
npm notice === Tarball Details ===
npm notice name:          gitlog
npm notice version:       4.0.8
npm notice filename:      gitlog-4.0.8.tgz
npm notice package size:  18.6 kB
npm notice unpacked size: 92.7 kB
npm notice shasum:        50b2cdd949c12dde92e09ba458b41fe578320307
npm notice integrity:     sha512-TXGm7onw4826N[...]b5Y5A5M6vRdtA==
npm notice total files:   11
npm notice
gitlog-4.0.8.tgz
```

Fixes: https://github.com/domharrington/node-gitlog/issues/93

## Change Type

Indicate the type of change your pull request is:

- [ ] `patch`
- [x] `minor`
- [ ] `major`
