### PR TITLE
chore: make it so that dependabot only cares about production dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: production


### PR DESCRIPTION
## What's Changing

This module itself has very few dependencies, but there are a lot of open dependabot PRs for development dependencies that do not matter as much if they're fully up to date.

## Change Type

Indicate the type of change your pull request is:

- [ ] `patch`
- [x] `minor`
- [ ] `major`
