### PR TITLE
fix: set delimiter to \x1E (record separator )

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import createDebugger from "debug";
 
 const debug = createDebugger("gitlog");
 
-const delimiter = "\t";
+const delimiter = "\x1E";
 const fieldMap = {
   hash: "%H",
   abbrevHash: "%h",


### PR DESCRIPTION
Allow tabs in commit messages by using the much more esoteric record separator (\x1E). \0 was is not allowed by git.

## What's Changing
delimiter used in git log pretty format is changed from `\t` (tab) to `\x1E` (record separator).

## Change Type
Fixes #97, tabs are now supported in commit messages

Indicate the type of change your pull request is:

- [X] `patch`
- [ ] `minor`
- [ ] `major`
