### PR TITLE
Add follow option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This option is disabled by default.
 
 ### follow
 
-Pass the -follow option to follow files across renames.
+Pass the --follow option to follow files across renames.
 
 This option is disabled by default.
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Pass the `-m` option to includes files in a merge commit.
 
 This option is disabled by default.
 
+### follow
+
+Pass the -follow option to follow files across renames.
+
+This option is disabled by default.
+
 ### all
 
 Find commits on all branches instead of just on the current one.

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,12 @@ export interface GitlogOptions<Fields extends string = DefaultField> {
    */
   includeMergeCommitFiles?: boolean;
   /**
+   * Pass the -follow option to follow files across renames
+   *
+   * @default false
+   */
+  follow?: boolean;
+  /**
    * The number of commits to return
    *
    * @default 10
@@ -128,6 +134,7 @@ const defaultOptions = {
   fields: defaultFields,
   nameStatus: true,
   includeMergeCommitFiles: false,
+  follow: false,
   findCopiesHarder: false,
   all: false,
 };
@@ -256,6 +263,10 @@ function createCommandArguments<
 
   if (options.includeMergeCommitFiles) {
     command.push("-m");
+  }
+
+  if (options.follow) {
+    command.push("--follow");
   }
 
   command.push(`-n ${options.number}`);

--- a/test/gitlog.test.ts
+++ b/test/gitlog.test.ts
@@ -249,6 +249,23 @@ describe("gitlog", () => {
     expect(commits[3].files[0]).toBe("foo");
   });
 
+  it("doesn't return commits for renamed files when follow is false or undefined", async () => {
+    const commits = await gitlog({
+      repo: testRepoLocation,
+      file: "1-fileRename",
+    });
+    expect(commits.length).toBe(2);
+  });
+
+  it("returns commits for renamed files when follow is true", async () => {
+    const commits = await gitlog({
+      repo: testRepoLocation,
+      file: "1-fileRename",
+      follow: true,
+    });
+    expect(commits.length).toBe(3);
+  });
+
   describe("Only repo option", () => {
     let commits: any[];
     beforeAll(async () => {


### PR DESCRIPTION
## What's Changing

Add follow option to add the --follow parameter when executing `git log`

## Change Type

Indicate the type of change your pull request is:

- [ ] `patch`
- [X] `minor`
- [ ] `major`
